### PR TITLE
Fix typo in the post_nav macro

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -30,7 +30,7 @@
         {% else %}
             <span>&laquo; {{ extra.label_previous }}</span>
         {% endif %}
-            <span class="pages"> {{ extra.label_page }} {{ ref.current_index }} {{extra.label_of}} {{ ref.pagers | length }} </span>
+            <span class="pages"> {{ extra.label_page }} {{ ref.current_index }} {{extra.label_of}} {{ ref.pages | length }} </span>
         {% if ref.next %}
             <a href="{{ ref.next }}">{{ extra.label_next }} &raquo;</a>
         {% else %}


### PR DESCRIPTION
I did this because it wouldn't actually build the site using this theme
until I fixed this issue.