### PR TITLE
Switch site.css & blog_logo paths to relative root

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,7 @@
 
     {% block css %}
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600|Source+Code+Pro">
-        <link rel="stylesheet" href="{{ get_url(path="site.css", trailing_slash=false) }}">
+        <link rel="stylesheet" href="/site.css">
     {% endblock css %}
 </head>
 <body>
@@ -77,7 +77,7 @@
             <a class="title" href="{{config.base_url}}">
                 {% block header_title %}
                     {% if config.extra.blog_logo %}
-                        <img src="{{ get_url(path=config.extra.blog_logo, trailing_slash=false) }}" alt="">
+                        <img src="{{ config.extra.blog_logo }}" alt="">
                     {% endif %}
                     {% if config.extra.blog_title %}
                         <h1 >{{config.extra.blog_title}}</h1>


### PR DESCRIPTION
I did this because the way they were currently implemented they were
explicitly templating the domain specified in the config. This isn't
always ideal. For instance lets say you want to test it out in a
different netlify branch based build or something. I believe this should
work correctly in all the normal cases as well.