### PR TITLE
Fix pagination navigation correctly

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -30,7 +30,7 @@
         {% else %}
             <span>&laquo; {{ extra.label_previous }}</span>
         {% endif %}
-            <span class="pages"> {{ extra.label_page }} {{ ref.current_index }} {{extra.label_of}} {{ ref.pages | length }} </span>
+            <span class="pages"> {{ extra.label_page }} {{ ref.current_index }} {{extra.label_of}} {{ ref.number_pagers }} </span>
         {% if ref.next %}
             <a href="{{ ref.next }}">{{ extra.label_next }} &raquo;</a>
         {% else %}


### PR DESCRIPTION
The previous ref.pages | length case made it compile but it was
returning the number of posts on a given page not the total number of
pages. ref.number_pagers now returns the correct number so that it
behaves as the user would expect and it compiles.