### PR TITLE
Fix a couple i18n cases that were missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ label_next = "Próxima"
 label_previous = "Anterior"
 label_page = "Página"
 label_of = "de"
+label_minutes = "minutos"
 
 og_image="" # Image that will appear on social media
 og_alt_image="" # Alt for og_image

--- a/templates/categories/single.html
+++ b/templates/categories/single.html
@@ -1,7 +1,7 @@
 {% extends "index.html" %}
 {% block content %}
     <main class="main">
-        <h3 class="page-title"> Categoria: {{term.name}} </h3>
+      <h3 class="page-title"> {{config.extra.label_category}}: {{term.name}} </h3>
         {% for page in term.pages %}
             {{ macro::post(page=page) }}
         {% endfor %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -17,7 +17,7 @@
             </address>
             <div class="extra">
                 <span itemprop="datePublished">{{ page.date | date(format="%d/%m/%Y") }}</span>
-                - {{ page.reading_time }} minutos
+                - {{ page.reading_time }} {{ config.extra.label_minutes }}
             </div>
         </article>
     </a>


### PR DESCRIPTION
There were a couple cases where i18n wasn't handled completely. This addresses them by fixing the singular category case to use the existing documented `label_category` as well as introducing a new `label_minute`.