### PR TITLE
Add: i18n to `minutes`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,7 @@ taxonomies = [
 blog_title="Dinkleberg"
 label_tags = "Tags"
 label_tag = "Tag"
+label_minutes = "Minutes"
 label_categories = "Categories"
 label_category = "Category"
 label_relative_posts = "Relative Posts"

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -17,7 +17,7 @@
             </address>
             <div class="extra">
                 <span itemprop="datePublished">{{ page.date | date(format="%d/%m/%Y") }}</span>
-                - {{ page.reading_time }} minutos
+                - {{ page.reading_time }} {{config.extra.label_minutes}}
             </div>
         </article>
     </a>


### PR DESCRIPTION
This PR adds another i18n label to the `config.toml` namely,
`label_minutes` this is used in the page listing (index.html).
Macro has been appropriately updated.

Previously, this macro was in Portuguese! 🇵🇹 🇧🇷 